### PR TITLE
feat: add support for versioned docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,55 @@
 
 A simple GitHub Action to deploy already generated static pages to GitHub Pages.
 
-## Environment variables
+## Inputs
 
-* `DOCS_PATH` - defaults to `docs`
-* `PUBLISH_BRANCH` - defaults to `gh-pages`
-* `SHOW_UNDERSCORE_FILES` - if set, adds a `.nojekyll` file to the root so files that start with
+* `docsPath` - The folder where the generated docs are located, defaults to `docs`.
+* `gitCommitEmail`: The email to use when committing to the repository, defaults to the repository
+  owner's fake GitHub email.
+* `gitCommitFlags`: Any extra `git commit` flags to pass, such as `--no-verify`.
+* `gitCommitUser`: The value to set `git config user.name`, defaults to the repository owner.
+* `publishBranch` - The branch name that GitHub Pages uses to build the website, defaults
+  to `gh-pages`.
+* `showUnderscoreFiles` - If set, adds a `.nojekyll` file to the root so files that start with
   `_` are accessible.
+* `versionDocs`- If set, put docs for all branches and tags in their own subfolders, defaults
+  to `false`.
+
+## Secrets used
+
+This action uses one of two methods to push the commit back up to the repository:
+
+* If `GH_PAGES_SSH_DEPLOY_KEY` is specified in the repository secrets, it is used to push the
+  commit back to the repository's SSH endpoint.
+* Otherwise, `GITHUB_TOKEN` is used to push the commit back to the repository's HTTPS endpoint. This
+  currently only works with private repositories. See the [GitHub Actions forum post](https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869) for details.
+
+## Example workflow
+
+```yaml
+name: Publish Documentation
+
+on: [create]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+    - name: Build docs
+    - run: make docs
+    - name: Publish docs
+      uses: malept/github-action-gh-pages@master
+      with:
+        gitCommitUser: Docs Publisher Bot
+      env:
+        DOCS_SSH_DEPLOY_KEY: ${{ secrets.DOCS_SSH_DEPLOY_KEY }}
+```
+
+In a production setting, `master` should be a tagged version (e.g., `v1.0.0`).
+
+## Debugging
+
+If you need to debug the `entrypoint.sh` script, you can set the `GH_PAGES_DEBUG` environment
+variable, which sets `-x` in the shell script.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+    - run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
     - name: Build docs
     - run: make docs
     - name: Publish docs

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,32 @@
+name: Publish to GitHub Pages
+description: Deploys already generated static pages to GitHub Pages.
+branding:
+  icon: book
+  color: gray-dark
+inputs:
+  docsPath:
+    description: 'The folder where the generated docs are located, defaults to `docs`.'
+    required: false
+  gitCommitEmail:
+    description: The email to use when committing to the repository, defaults to the repository owner's fake GitHub email.
+    required: false
+    default: ''
+  gitCommitFlags:
+    description: 'Any extra `git commit` flags to pass, such as `--no-verify`.'
+    default: ''
+    required: false
+  gitCommitUser:
+    description: 'The value to set `git config user.name`, defaults to the repository owner.'
+    required: false
+  publishBranch:
+    description: 'The branch name that GitHub Pages uses to build the website, defaults to `gh-pages`.'
+    required: false
+  showUnderscoreFiles:
+    description: 'If set, adds a `.nojekyll` file to the root so files that start with `_` are accessible.'
+    required: false
+  versionDocs:
+    description: 'If set, put docs for all branches and tags in their own subfolders, defaults to `false`.'
+    required: false
+runs:
+  using: docker
+  image: Dockerfile

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,30 +1,84 @@
 #!/bin/sh
 
-set +e
+set -e
 
-if test -z "$DOCS_PATH"; then
+if test -n "$GH_PAGES_DEBUG"; then
+    set -x
+fi
+
+if test -n "$INPUT_DOCSPATH"; then
+    DOCS_PATH="$INPUT_DOCSPATH"
+else
     DOCS_PATH=docs
 fi
 
-if test -z "$PUBLISH_BRANCH"; then
+if test -z "$INPUT_GITCOMMITEMAIL"; then
+    INPUT_GITCOMMITEMAIL="$GITHUB_ACTOR@users.noreply.github.com"
+fi
+
+if test -z "$INPUT_GITCOMMITUSER"; then
+    INPUT_GITCOMMITUSER="$GITHUB_ACTOR"
+fi
+
+if test -n "$INPUT_PUBLISHBRANCH"; then
+    PUBLISH_BRANCH="$INPUT_PUBLISHBRANCH"
+else
     PUBLISH_BRANCH=gh-pages
 fi
 
-if git branch --list | grep -q $PUBLISH_BRANCH; then
-    git branch -D $PUBLISH_BRANCH
+if test -n "$INPUT_VERSIONDOCS"; then
+    if test -n "$INPUT_GITREVISION"; then
+        GIT_REVISION="$INPUT_GITREVISION"
+    elif test -n "$GITHUB_REF"; then
+        GIT_REVISION="$(echo $GITHUB_REF | sed -e 's:refs/\(head\|tag\)s/::g')"
+    fi
 fi
 
-git checkout --orphan $PUBLISH_BRANCH
-cp -R $DOCS_PATH /github/docs
-git rm --cached -r .
-mv /github/docs/* .
+if test -n "$GIT_REVISION"; then
+    DOC_TARGET_DIR="$GIT_REVISION"
+elif test -n "$INPUT_VERSIONDOCS"; then
+    DOC_TARGET_DIR=master
+    echo "<html><head><meta http-equiv='refresh' content='0; url=$DOC_TARGET_DIR/'></head></html>" > index.html
+else
+    DOC_TARGET_DIR=.
+fi
 
-if test -n $SHOW_UNDERSCORE_FILES; then
-    touch .nojekyll
+if ! git branch --list --remote | grep --quiet origin/$PUBLISH_BRANCH; then
+    git checkout --orphan $PUBLISH_BRANCH
+    git rm --cached .gitignore
+    git rm --force -r .
+
+    if test -n $INPUT_SHOWUNDERSCOREFILES; then
+        touch .nojekyll
+    fi
+else
+    git checkout $PUBLISH_BRANCH
+    if test "$DOC_TARGET_DIR" != "." -a -d "$DOC_TARGET_DIR"; then
+        rm -r "$DOC_TARGET_DIR"
+    fi
+fi
+
+if test "$DOC_TARGET_DIR" == "."; then
+    mv "$DOCS_PATH"/* .
+    rm -r "$DOCS_PATH"/
+else
+    mv "$DOCS_PATH" "$DOC_TARGET_DIR"
+fi
+
+if test -n "$GH_PAGES_SSH_DEPLOY_KEY"; then
+    mkdir ~/.ssh
+    echo "$GH_PAGES_SSH_DEPLOY_KEY" > ~/.ssh/deploy_key
+    chmod 400 ~/.ssh/deploy_key
+
+    git remote rm origin
+    git remote add origin "git@github.com:$GITHUB_REPOSITORY.git"
+else
+    echo "machine github.com login $GITHUB_ACTOR password $GITHUB_TOKEN" > ~/.netrc
+    chmod 600 ~/.netrc
 fi
 
 git add .
-git config user.name "$GITHUB_ACTOR"
-git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-git commit -m "Publish"
-git push -f origin $PUBLISH_BRANCH
+git config user.name "$INPUT_GITCOMMITUSER"
+git config user.email "$INPUT_GITCOMMITEMAIL"
+git commit $INPUT_GITCOMMITFLAGS -m "Publish"
+GIT_SSH_COMMAND="ssh -i ~/.ssh/deploy_key" git push origin HEAD:$PUBLISH_BRANCH

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,7 +54,7 @@ if ! git branch --list --remote | grep --quiet origin/$PUBLISH_BRANCH; then
 else
     git checkout $PUBLISH_BRANCH
     if test "$DOC_TARGET_DIR" != "." -a -d "$DOC_TARGET_DIR"; then
-        rm -r "$DOC_TARGET_DIR"
+        git rm -r "$DOC_TARGET_DIR"
     fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,20 +65,24 @@ else
     mv "$DOCS_PATH" "$DOC_TARGET_DIR"
 fi
 
-if test -n "$GH_PAGES_SSH_DEPLOY_KEY"; then
-    mkdir ~/.ssh
-    echo "$GH_PAGES_SSH_DEPLOY_KEY" > ~/.ssh/deploy_key
-    chmod 400 ~/.ssh/deploy_key
-
-    git remote rm origin
-    git remote add origin "git@github.com:$GITHUB_REPOSITORY.git"
-else
-    echo "machine github.com login $GITHUB_ACTOR password $GITHUB_TOKEN" > ~/.netrc
-    chmod 600 ~/.netrc
-fi
-
 git add .
-git config user.name "$INPUT_GITCOMMITUSER"
-git config user.email "$INPUT_GITCOMMITEMAIL"
-git commit $INPUT_GITCOMMITFLAGS -m "Publish"
-GIT_SSH_COMMAND="ssh -i ~/.ssh/deploy_key" git push origin HEAD:$PUBLISH_BRANCH
+
+if test -n "$(git status -s)"; then
+    git config user.name "$INPUT_GITCOMMITUSER"
+    git config user.email "$INPUT_GITCOMMITEMAIL"
+    git commit $INPUT_GITCOMMITFLAGS -m "Publish"
+
+    if test -n "$GH_PAGES_SSH_DEPLOY_KEY"; then
+        mkdir ~/.ssh
+        echo "$GH_PAGES_SSH_DEPLOY_KEY" > ~/.ssh/deploy_key
+        chmod 400 ~/.ssh/deploy_key
+
+        git remote rm origin
+        git remote add origin "git@github.com:$GITHUB_REPOSITORY.git"
+    else
+        echo "machine github.com login $GITHUB_ACTOR password $GITHUB_TOKEN" > ~/.netrc
+        chmod 600 ~/.netrc
+    fi
+
+    GIT_SSH_COMMAND="ssh -i ~/.ssh/deploy_key" git push origin HEAD:$PUBLISH_BRANCH
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,7 +58,7 @@ else
     fi
 fi
 
-if test "$DOC_TARGET_DIR" == "."; then
+if test "$DOC_TARGET_DIR" = "."; then
     mv "$DOCS_PATH"/* .
     rm -r "$DOCS_PATH"/
 else


### PR DESCRIPTION
If set, put docs for all branches and tags in their own subfolders, defaults to `false`.

Also, replace environment variables with Action inputs and add an `action.yml`.
