### PR TITLE
fix: fetch github.com SSH host keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ LABEL "repository"="https://github.com/malept/github-action-gh-pages"
 LABEL "maintainer"="Mark Lee <https://github.com/malept>"
 
 RUN apt-get update && apt-get install -y --no-install-recommends git openssh-client && apt clean && rm -rf /var/lib/apt/lists/*
+RUN ssh-keyscan -H github.com >> /etc/ssh/ssh_known_hosts
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This fixes the following error:

```
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```