### PR TITLE
feat: add redirectURLSuffix input

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A simple GitHub Action to deploy already generated static pages to GitHub Pages.
 * `gitCommitUser` - The value to set `git config user.name`, defaults to the repository owner.
 * `publishBranch` - The branch name that GitHub Pages uses to build the website, defaults
   to `gh-pages`.
+* `redirectURLSuffix` - The path suffix for the redirect URL used in `index.html`, when
+  `versionDocs` is `true`.
 * `showUnderscoreFiles` - If set, adds a `.nojekyll` file to the root so files that start with
   `_` are accessible.
 * `versionDocs`- If set, put docs for all branches and tags in their own subfolders, defaults

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
   publishBranch:
     description: 'The branch name that GitHub Pages uses to build the website, defaults to `gh-pages`.'
     required: false
+  redirectURLSuffix:
+    description: 'The path suffix for the redirect URL used in `index.html`, when `versionDocs` is `true`.'
+    required: false
   showUnderscoreFiles:
     description: 'If set, adds a `.nojekyll` file to the root so files that start with `_` are accessible.'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,7 +68,8 @@ if test "$DOC_TARGET_DIR" = "."; then
     rm -r "$DOCS_PATH"/
 else
     if test -n "$INPUT_VERSIONDOCS" -a "$DOC_TARGET_DIR" = "$DEFAULT_BRANCH"; then
-        echo "<html><head><meta http-equiv='refresh' content='0; url=$DOC_TARGET_DIR/'></head></html>" > index.html
+        REDIRECT_URL="$DOC_TARGET_DIR/$INPUT_REDIRECTURLSUFFIX"
+        echo "<html><head><meta http-equiv='refresh' content='0; url=$REDIRECT_URL'></head></html>" > index.html
     fi
     mv "$DOCS_PATH" "$DOC_TARGET_DIR"
 fi


### PR DESCRIPTION
Particularly useful for generated rustdoc, where there's no `index.html` in the root of `target/doc`.