### PR TITLE
feat: add configurable commit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A simple GitHub Action to deploy already generated static pages to GitHub Pages.
 * `gitCommitEmail` - The email to use when committing to the repository, defaults to the repository
   owner's fake GitHub email.
 * `gitCommitFlags` - Any extra `git commit` flags to pass, such as `--no-verify`.
+* `gitCommitMessage` - The commit message to use when creating/updating the GitHub Pages branch.
+  Defaults to `Publish`.
 * `gitCommitUser` - The value to set `git config user.name`, defaults to the repository owner.
 * `publishBranch` - The branch name that GitHub Pages uses to build the website, defaults
   to `gh-pages`.

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Any extra `git commit` flags to pass, such as `--no-verify`.'
     default: ''
     required: false
+  gitCommitMessage:
+    description: 'The commit message to use when creating/updating the GitHub Pages branch.'
+    default: 'Publish'
+    required: false
   gitCommitUser:
     description: 'The value to set `git config user.name`, defaults to the repository owner.'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,10 @@ if test -z "$INPUT_GITCOMMITEMAIL"; then
     INPUT_GITCOMMITEMAIL="$GITHUB_ACTOR@users.noreply.github.com"
 fi
 
+if test -z "$INPUT_GITCOMMITMESSAGE"; then
+    INPUT_GITCOMMITMESSAGE="Publish"
+fi
+
 if test -z "$INPUT_GITCOMMITUSER"; then
     INPUT_GITCOMMITUSER="$GITHUB_ACTOR"
 fi
@@ -79,7 +83,7 @@ git add .
 if test -n "$(git status -s)"; then
     git config user.name "$INPUT_GITCOMMITUSER"
     git config user.email "$INPUT_GITCOMMITEMAIL"
-    git commit $INPUT_GITCOMMITFLAGS -m "Publish"
+    git commit $INPUT_GITCOMMITFLAGS --message "$INPUT_GITCOMMITMESSAGE"
 
     if test -n "$GH_PAGES_SSH_DEPLOY_KEY"; then
         mkdir ~/.ssh


### PR DESCRIPTION
Use case: append `[skip ci]` to the commit message so CI won't trigger on the `gh-pages` branch.