### PR TITLE
fix: install ca-certificates in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL "com.github.actions.color"="gray-dark"
 LABEL "repository"="https://github.com/malept/github-action-gh-pages"
 LABEL "maintainer"="Mark Lee <https://github.com/malept>"
 
-RUN apt-get update && apt-get install -y --no-install-recommends git openssh-client rsync && apt clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git openssh-client rsync && apt clean && rm -rf /var/lib/apt/lists/*
 RUN ssh-keyscan -H github.com >> /etc/ssh/ssh_known_hosts
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Fix for the following error when not using `GH_PAGES_SSH_DEPLOY_KEY`:

```
fatal: unable to access 'https://github.com/electron/electron-packager/': server certificate verification failed. CAfile: none CRLfile: none
```