### PR TITLE
fix: workaround for dubious ownership fatal error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,6 +52,9 @@ else
     DOC_TARGET_DIR=.
 fi
 
+# Work around the "fatal: detected dubious ownership" issue
+git config --global --add safe.directory '*'
+
 if ! git branch --list --remote | grep --quiet "origin/${PUBLISH_BRANCH}$"; then
     echo "Creating new $PUBLISH_BRANCH...."
     git checkout --orphan $PUBLISH_BRANCH

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,6 +53,7 @@ else
 fi
 
 # Work around the "fatal: detected dubious ownership" issue
+# See https://github.com/actions/runner-images/issues/6775#issuecomment-1410270956
 git config --global --add safe.directory '*'
 
 if ! git branch --list --remote | grep --quiet "origin/${PUBLISH_BRANCH}$"; then


### PR DESCRIPTION
The error originates in mismatching ownership of the git checkout once mounted into the container. Other reports of running into it have suggested it may happen as a result of different git versions used - which would be the case here since one git client is used to check out the code in the GitHub Actions workflow, and then this action uses its own different version of git to do other operations.

This is a suggested workaround - it's not great but does work.