### PR TITLE
feat: cname input

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A simple GitHub Action to deploy already generated static pages to GitHub Pages.
 
 ## Inputs
 
+* `cname`- If set, create a `CNAME` file with the provided value.
 * `defaultBranch` - The default branch name for the repository, defaults to `master` for
   backwards-compatiblity reasons. _Version 2.x will likely default to `main`_.
 * `docsPath` - The folder where the generated docs are located, defaults to `docs`.

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ branding:
   icon: book
   color: gray-dark
 inputs:
+  cname:
+    description: 'If set, create a `CNAME` file with the provided value.'
+    required: false
   defaultBranch:
     description: 'The default branch name for the repository, defaults to `master` for backwards-compatiblity reasons. Version 2.x will likely default to `main`.'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,6 +73,10 @@ else
     fi
 fi
 
+if test -n "$INPUT_CNAME"; then
+    echo "$INPUT_CNAME" > CNAME
+fi
+
 if test "$DOC_TARGET_DIR" = "."; then
     rsync --archive "$DOCS_PATH"/ ./
     rm -r "$DOCS_PATH"/


### PR DESCRIPTION
Trivial feature, just adding it so there's feature parity with `peaceiris/actions-gh-pages` which `electron/forge` currently uses so that I can swap Forge to using this project to match `electron/get` and `electron/packager`.