### PR TITLE
feat: noCommit input

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A simple GitHub Action to deploy already generated static pages to GitHub Pages.
 * `gitCommitMessage` - The commit message to use when creating/updating the GitHub Pages branch.
   Defaults to `Publish`.
 * `gitCommitUser` - The value to set `git config user.name`, defaults to the repository owner.
+* `noCommit` - If set, stage changes but do not commit them, defaults to `false`.
 * `publishBranch` - The branch name that GitHub Pages uses to build the website, defaults
   to `gh-pages`.
 * `redirectURLSuffix` - The path suffix for the redirect URL used in `index.html`, when

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
   gitCommitUser:
     description: 'The value to set `git config user.name`, defaults to the repository owner.'
     required: false
+  noCommit:
+    description: 'If set, stage changes but do not commit them, defaults to `false`.'
+    required: false
   publishBranch:
     description: 'The branch name that GitHub Pages uses to build the website, defaults to `gh-pages`.'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -86,22 +86,28 @@ fi
 
 git add .
 
-if test -n "$(git status -s)"; then
-    git config user.name "$INPUT_GITCOMMITUSER"
-    git config user.email "$INPUT_GITCOMMITEMAIL"
-    git commit $INPUT_GITCOMMITFLAGS --message "$INPUT_GITCOMMITMESSAGE"
+if test -z "$INPUT_NOCOMMIT"; then
+    if test -n "$(git status -s)"; then
+        git config user.name "$INPUT_GITCOMMITUSER"
+        git config user.email "$INPUT_GITCOMMITEMAIL"
+        git commit $INPUT_GITCOMMITFLAGS --message "$INPUT_GITCOMMITMESSAGE"
 
-    if test -n "$GH_PAGES_SSH_DEPLOY_KEY"; then
-        mkdir ~/.ssh
-        echo "$GH_PAGES_SSH_DEPLOY_KEY" > ~/.ssh/deploy_key
-        chmod 400 ~/.ssh/deploy_key
+        if test -n "$GH_PAGES_SSH_DEPLOY_KEY"; then
+            mkdir ~/.ssh
+            echo "$GH_PAGES_SSH_DEPLOY_KEY" > ~/.ssh/deploy_key
+            chmod 400 ~/.ssh/deploy_key
 
-        git remote rm origin
-        git remote add origin "git@github.com:$GITHUB_REPOSITORY.git"
+            git remote rm origin
+            git remote add origin "git@github.com:$GITHUB_REPOSITORY.git"
+        else
+            echo "machine github.com login $GITHUB_ACTOR password $GITHUB_TOKEN" > ~/.netrc
+            chmod 600 ~/.netrc
+        fi
+
+        GIT_SSH_COMMAND="ssh -i ~/.ssh/deploy_key" git push origin HEAD:$PUBLISH_BRANCH
     else
-        echo "machine github.com login $GITHUB_ACTOR password $GITHUB_TOKEN" > ~/.netrc
-        chmod 600 ~/.netrc
+        echo "Skipping commit since no changes to commit"
     fi
-
-    GIT_SSH_COMMAND="ssh -i ~/.ssh/deploy_key" git push origin HEAD:$PUBLISH_BRANCH
+else
+    echo "Skipping commit since noCommit input was set"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -86,7 +86,9 @@ fi
 
 git add .
 
-if test -z "$INPUT_NOCOMMIT"; then
+if test -n "$INPUT_NOCOMMIT"; then
+    echo "Skipping commit since noCommit input was set"
+else
     if test -n "$(git status -s)"; then
         git config user.name "$INPUT_GITCOMMITUSER"
         git config user.email "$INPUT_GITCOMMITEMAIL"
@@ -108,6 +110,4 @@ if test -z "$INPUT_NOCOMMIT"; then
     else
         echo "Skipping commit since no changes to commit"
     fi
-else
-    echo "Skipping commit since noCommit input was set"
 fi


### PR DESCRIPTION
Feature to not commit and push, only stage the changes. This leaves the checkout in the ready to commit state which allows another action ([`dsanders11/github-app-commit-action`](https://github.com/dsanders11/github-app-commit-action)) to do the commit and get verified commits via GitHub's API.